### PR TITLE
Unwrap InvocationTargetException on DeferredRestOperations

### DIFF
--- a/spring-kotlin-coroutine/src/main/kotlin/org/springframework/kotlin/experimental/coroutine/proxy/provider/DeferredFromRegularMethodInvokerProvider.kt
+++ b/spring-kotlin-coroutine/src/main/kotlin/org/springframework/kotlin/experimental/coroutine/proxy/provider/DeferredFromRegularMethodInvokerProvider.kt
@@ -22,6 +22,7 @@ import org.springframework.kotlin.experimental.coroutine.proxy.CoroutineProxyCon
 import org.springframework.kotlin.experimental.coroutine.proxy.DeferredCoroutineProxyConfig
 import org.springframework.kotlin.experimental.coroutine.proxy.MethodInvoker
 import org.springframework.kotlin.experimental.coroutine.proxy.MethodInvokerProvider
+import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
 object DeferredFromRegularMethodInvokerProvider : MethodInvokerProvider {
@@ -46,7 +47,11 @@ object DeferredFromRegularMethodInvokerProvider : MethodInvokerProvider {
     private fun createDeferredFromRegularMethodInvoker(proxyConfig: DeferredCoroutineProxyConfig, regularMethod: Method, obj: Any) =
         object : MethodInvoker {
             override fun invoke(vararg args: Any): Any? = async(proxyConfig.coroutineContext, proxyConfig.start) {
-                regularMethod.invoke(obj, *args)
+                try {
+                    regularMethod.invoke(obj, *args)
+                } catch (ex: InvocationTargetException) {
+                    throw ex.targetException
+                }
             }
         }
 }

--- a/spring-kotlin-coroutine/src/main/kotlin/org/springframework/kotlin/experimental/coroutine/proxy/provider/SameMethodInvokerProvider.kt
+++ b/spring-kotlin-coroutine/src/main/kotlin/org/springframework/kotlin/experimental/coroutine/proxy/provider/SameMethodInvokerProvider.kt
@@ -19,6 +19,7 @@ package org.springframework.kotlin.experimental.coroutine.proxy.provider
 import org.springframework.kotlin.experimental.coroutine.proxy.CoroutineProxyConfig
 import org.springframework.kotlin.experimental.coroutine.proxy.MethodInvoker
 import org.springframework.kotlin.experimental.coroutine.proxy.MethodInvokerProvider
+import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
 object SameMethodInvokerProvider: MethodInvokerProvider {
@@ -33,7 +34,11 @@ object SameMethodInvokerProvider: MethodInvokerProvider {
         }?.let { regularMethod ->
             object : MethodInvoker {
                 override fun invoke(vararg args: Any): Any? =
-                        regularMethod.invoke(obj, *args)
+                        try {
+                            regularMethod.invoke(obj, *args)
+                        } catch (ex: InvocationTargetException) {
+                            throw ex.targetException
+                        }
             }
         }
 }

--- a/spring-kotlin-coroutine/src/test/groovy/org/springframework/kotlin/experimental/coroutine/web/client/CoroutineRestOperationsIntSpec.groovy
+++ b/spring-kotlin-coroutine/src/test/groovy/org/springframework/kotlin/experimental/coroutine/web/client/CoroutineRestOperationsIntSpec.groovy
@@ -6,6 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.kotlin.experimental.coroutine.IntSpecConfiguration
 import org.springframework.kotlin.experimental.coroutine.web.TestWebConfiguration
+import org.springframework.web.client.HttpClientErrorException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -29,5 +30,17 @@ class CoroutineRestOperationsIntSpec extends Specification {
         then:
         result.statusCode == HttpStatus.OK
         result.body == 5*7
+    }
+
+    @Unroll
+    def "should handle 404 error from REST controller with CoroutineRestOperations"() {
+        when:
+        runBlocking { cont ->
+            coroutineRestOperations.getForEntity("http://localhost:$port/notfound", Integer.TYPE, new Object[0], cont)
+        }
+
+        then:
+        def exception = thrown(HttpClientErrorException.class)
+        exception.statusCode == HttpStatus.NOT_FOUND
     }
 }

--- a/spring-kotlin-coroutine/src/test/groovy/org/springframework/kotlin/experimental/coroutine/web/client/DeferredRestOperationsIntSpec.groovy
+++ b/spring-kotlin-coroutine/src/test/groovy/org/springframework/kotlin/experimental/coroutine/web/client/DeferredRestOperationsIntSpec.groovy
@@ -1,11 +1,12 @@
 package org.springframework.kotlin.experimental.coroutine.web.client
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.http.HttpStatus
 import org.springframework.kotlin.experimental.coroutine.IntSpecConfiguration
 import org.springframework.kotlin.experimental.coroutine.web.TestWebConfiguration
+import org.springframework.web.client.HttpClientErrorException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -29,6 +30,17 @@ class DeferredRestOperationsIntSpec extends Specification {
 
         then:
         result.statusCode == HttpStatus.OK
-        result.body == 5*7
+        result.body == 5 * 7
+    }
+
+    def "should handle 404 error from REST controller with DeferredRestOperations"() {
+        when:
+        runBlocking { cont ->
+            deferredRestOperations.getForEntity("http://localhost:$port/notfound", Integer.TYPE).await(cont)
+        }
+
+        then:
+        def exception = thrown(HttpClientErrorException.class)
+        exception.statusCode == HttpStatus.NOT_FOUND
     }
 }

--- a/spring-kotlin-coroutine/src/test/kotlin/org/springframework/kotlin/experimental/coroutine/web/TestController.kt
+++ b/spring-kotlin-coroutine/src/test/kotlin/org/springframework/kotlin/experimental/coroutine/web/TestController.kt
@@ -1,6 +1,5 @@
 package org.springframework.kotlin.experimental.coroutine.web
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -12,5 +11,5 @@ open class TestController {
     open fun multiply(@PathVariable("a") a: Int, @PathVariable("b") b: Int): Int = a*b
 
     @GetMapping("/notfound")
-    open fun notfound() = ResponseEntity<Any?>(HttpStatus.NOT_FOUND)
+    open fun notfound(): ResponseEntity<Int> = ResponseEntity.notFound().build()
 }

--- a/spring-kotlin-coroutine/src/test/kotlin/org/springframework/kotlin/experimental/coroutine/web/TestController.kt
+++ b/spring-kotlin-coroutine/src/test/kotlin/org/springframework/kotlin/experimental/coroutine/web/TestController.kt
@@ -1,5 +1,7 @@
 package org.springframework.kotlin.experimental.coroutine.web
 
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
@@ -8,4 +10,7 @@ import org.springframework.web.bind.annotation.RestController
 open class TestController {
     @GetMapping("/multiply/{a}/{b}")
     open fun multiply(@PathVariable("a") a: Int, @PathVariable("b") b: Int): Int = a*b
+
+    @GetMapping("/notfound")
+    open fun notfound() = ResponseEntity<Any?>(HttpStatus.NOT_FOUND)
 }


### PR DESCRIPTION
I think DeferredRestOperations should return same exceptions as original RestOperations, so they can be used as drop in replacement.

Probably this change should be also applied for CoroutineRestOperations, but I wanted to know your opinion first.