### PR TITLE
Additional functionality to CoroutineWebClient

### DIFF
--- a/spring-webflux-kotlin-coroutine/src/test/groovy/org/springframework/kotlin/experimental/coroutine/CoroutineWebClientSpec.groovy
+++ b/spring-webflux-kotlin-coroutine/src/test/groovy/org/springframework/kotlin/experimental/coroutine/CoroutineWebClientSpec.groovy
@@ -1,12 +1,16 @@
 package org.springframework.kotlin.experimental.coroutine
 
+
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.kotlin.experimental.coroutine.web.WebConfiguration
+import org.springframework.web.coroutine.function.client.CoroutineClientResponse
 import org.springframework.web.coroutine.function.client.CoroutineWebClient
 import org.springframework.web.coroutine.function.client.CoroutineWebClientUtils
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import spock.lang.Specification
 
 import static org.springframework.kotlin.experimental.coroutine.TestUtilsKt.runBlocking
@@ -14,25 +18,83 @@ import static org.springframework.kotlin.experimental.coroutine.TestUtilsKt.runB
 @SpringBootTest(classes = [IntSpecConfiguration, WebConfiguration], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration
 class CoroutineWebClientSpec extends Specification {
+
     @LocalServerPort
     private int port
 
-    def "should be able to access endpoint with CoroutineWebClient with custom header"() {
+    def "should be able to access endpoint with CoroutineWebClient with custom header and body using retrieve()"() {
         when:
         final String url = "http://localhost:$port"
-        final CoroutineWebClient.CoroutineResponseSpec spec = runBlocking { cont ->
-            CoroutineWebClientUtils.createCoroutineWebClient(url)
-                    .post()
-                    .uri("/postWithHeaderTest")
-                    .header("X-Coroutine-Test", "123456")
-                    .retrieve(cont)
-        }
+        final CoroutineWebClient.CoroutineResponseSpec spec = CoroutineWebClientUtils.createCoroutineWebClient(url)
+                .post()
+                .uri("/postWithHeaderAndBodyTest")
+                .header("X-Coroutine-Test", "123456")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body([text: "free-text", num: 1, flag: true], Map)
+                .retrieve()
 
-        final String response = runBlocking { cont ->
-            spec.body(String, cont)
+        final Map<String, Object> response = runBlocking { cont ->
+            spec.body(Map, cont)
         }
 
         then:
-        response == "123456"
+        response["header"] == "123456"
+        response["body"] == [text: "free-text", num: 1, flag: true]
+    }
+
+    def "should be able to access endpoint with CoroutineWebClient with custom header and body using exchange()"() {
+        when:
+        final String url = "http://localhost:$port"
+        final CoroutineClientResponse resp = runBlocking { cont ->
+            CoroutineWebClientUtils.createCoroutineWebClient(url)
+                    .post()
+                    .uri("/postWithHeaderAndBodyTest")
+                    .header("X-Coroutine-Test", "123456")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body([text: "free-text", num: 1, flag: true], Map)
+                    .exchange(cont)
+        }
+
+        final Map<String, Object> responseBody = runBlocking { cont ->
+            resp.body(Map, cont)
+        }
+
+        then:
+        resp.statusCode() == HttpStatus.CREATED
+        responseBody["header"] == "123456"
+        responseBody["body"] == [text: "free-text", num: 1, flag: true]
+    }
+
+    def "should fail to access endpoint with CoroutineWebClient with invalid content-type using exchange()"() {
+        when:
+        final String url = "http://localhost:$port"
+        final CoroutineClientResponse resp = runBlocking { cont ->
+            CoroutineWebClientUtils.createCoroutineWebClient(url)
+                    .post()
+                    .uri("/postWithHeaderAndBodyTest")
+                    .contentType(MediaType.IMAGE_JPEG)
+                    .exchange(cont)
+        }
+
+        then:
+        resp.statusCode() == HttpStatus.UNSUPPORTED_MEDIA_TYPE
+    }
+
+    def "should fail to access endpoint with CoroutineWebClient with invalid content-type using retrieve()"() {
+        when:
+        final String url = "http://localhost:$port"
+        runBlocking { cont ->
+            CoroutineWebClientUtils.createCoroutineWebClient(url)
+                    .post()
+                    .uri("/postWithHeaderAndBodyTest")
+                    .contentType(MediaType.IMAGE_GIF)
+                    .retrieve()
+                    .body(Map, cont)
+        }
+
+        then:
+        def e = thrown WebClientResponseException
+        e.statusCode == HttpStatus.UNSUPPORTED_MEDIA_TYPE
+        e.statusText == "Unsupported Media Type"
     }
 }

--- a/spring-webflux-kotlin-coroutine/src/test/kotlin/org/springframework/kotlin/experimental/coroutine/web/CoroutineController.kt
+++ b/spring-webflux-kotlin-coroutine/src/test/kotlin/org/springframework/kotlin/experimental/coroutine/web/CoroutineController.kt
@@ -20,13 +20,16 @@ import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.channels.produce
 import kotlinx.coroutines.experimental.delay
+import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.MediaType
 import org.springframework.kotlin.experimental.coroutine.annotation.Coroutine
 import org.springframework.kotlin.experimental.coroutine.context.COMMON_POOL
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -72,19 +75,19 @@ open class CoroutineController {
 
     @GetMapping("/sseChannelMultiply/{a}/{b}", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
     open fun sseChannelMultiply(@PathVariable("a") a: Int, @PathVariable("b") b: Int) = //: ReceiveChannel<Int>
-            channelMultiply(a, b)
+        channelMultiply(a, b)
 
     @GetMapping("/sseDelayedChannelMultiply/{a}/{b}", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
     open suspend fun sseDelayedChannelMultiply(@PathVariable("a") a: Int, @PathVariable("b") b: Int): ReceiveChannel<Int> =
-            delayedChannelMultiply(a, b)
+        delayedChannelMultiply(a, b)
 
     @GetMapping("/sseChannelMultiplyList/{a}/{b}", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
     open suspend fun sseChannelMultiplyList(@PathVariable("a") a: Int, @PathVariable("b") b: Int): List<Int> =
-            channelMultiplyList(a, b)
+        channelMultiplyList(a, b)
 
     @GetMapping("/sseSuspendChannelMultiply/{a}/{b}", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
     open suspend fun sseSuspendChannelMultiply(@PathVariable("a") a: Int, @PathVariable("b") b: Int) = //: ReceiveChannel<Int>
-            suspendChannelMultiply(a, b)
+        suspendChannelMultiply(a, b)
 
     @GetMapping("/test", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
     open fun test() = produce(CommonPool) {
@@ -105,6 +108,11 @@ open class CoroutineController {
     @PostMapping("/postTest")
     open suspend fun postTest(): Int = 123456
 
-    @PostMapping("/postWithHeaderTest")
-    open suspend fun postWithHeaderTest(@RequestHeader("X-Coroutine-Test") headerValue: String): String = headerValue
+    @ResponseStatus(CREATED)
+    @PostMapping("/postWithHeaderAndBodyTest", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    open suspend fun postWithHeaderAndBodyTest(
+        @RequestHeader("X-Coroutine-Test") headerValue: String,
+        @RequestBody body: Map<String, Any>
+    ): Map<String, Any> = mapOf("header" to headerValue, "body" to body)
+
 }


### PR DESCRIPTION
Added missing methods to `CoroutineWebClient` by implementing `CoroutineClientResponse`.
Also added missing methods to `RequestBodySpec`

Removed `suspend` keyword from `CoroutineWebClient.RequestHeadersSpec.retrieve()` as it does no blocking operations, but only wraps `WebClient.ResponseSpec` and prepares exchange which can be invoked by calling `body()` method