### PR TITLE
Added missing HttpMethods to RouterFunctionDsl

### DIFF
--- a/spring-webflux-kotlin-coroutine/src/main/kotlin/org/springframework/web/coroutine/function/server/CoroutineRouterFunction.kt
+++ b/spring-webflux-kotlin-coroutine/src/main/kotlin/org/springframework/web/coroutine/function/server/CoroutineRouterFunction.kt
@@ -41,7 +41,17 @@ class CoroutineRouterFunctionDsl {
 
     infix fun RequestPredicate.and(other: String): RequestPredicate = this.and(path(other))
 
+    infix fun RequestPredicate.or(other: String): RequestPredicate = this.or(path(other))
+
+    infix fun String.and(other: RequestPredicate): RequestPredicate = path(this).and(other)
+
+    infix fun String.or(other: RequestPredicate): RequestPredicate = path(this).or(other)
+
+    infix fun RequestPredicate.and(other: RequestPredicate): RequestPredicate = this.and(other)
+
     infix fun RequestPredicate.or(other: RequestPredicate): RequestPredicate = this.or(other)
+
+    operator fun RequestPredicate.not(): RequestPredicate = this.negate()
 
     fun accept(mediaType: MediaType): RequestPredicate = RequestPredicates.accept(mediaType)
 
@@ -53,13 +63,47 @@ class CoroutineRouterFunctionDsl {
 
     suspend fun String.nest(r: CoroutineRoutes) = path(this).nest(r)
 
-    fun DELETE(pattern: String): RequestPredicate = RequestPredicates.DELETE(pattern)
-
-    fun GET(pattern: String) = RequestPredicates.GET(pattern)
-
-    fun <T: CoroutineServerResponse> GET(pattern: String, f: CoroutineHandlerFunction<T>) {
+    fun <T : CoroutineServerResponse> GET(pattern: String, f: CoroutineHandlerFunction<T>) {
         routes += route(RequestPredicates.GET(pattern), f.asHandlerFunction())
     }
+
+    fun GET(pattern: String): RequestPredicate = RequestPredicates.GET(pattern)
+
+    fun <T : CoroutineServerResponse> POST(pattern: String, f: CoroutineHandlerFunction<T>) {
+        routes += route(RequestPredicates.POST(pattern), f.asHandlerFunction())
+    }
+
+    fun POST(pattern: String): RequestPredicate = RequestPredicates.POST(pattern)
+
+    fun <T : CoroutineServerResponse> PUT(pattern: String, f: CoroutineHandlerFunction<T>) {
+        routes += route(RequestPredicates.PUT(pattern), f.asHandlerFunction())
+    }
+
+    fun PUT(pattern: String): RequestPredicate = RequestPredicates.PUT(pattern)
+
+    fun <T : CoroutineServerResponse> DELETE(pattern: String, f: CoroutineHandlerFunction<T>) {
+        routes += route(RequestPredicates.DELETE(pattern), f.asHandlerFunction())
+    }
+
+    fun DELETE(pattern: String): RequestPredicate = RequestPredicates.DELETE(pattern)
+
+    fun <T : CoroutineServerResponse> PATCH(pattern: String, f: CoroutineHandlerFunction<T>) {
+        routes += route(RequestPredicates.PATCH(pattern), f.asHandlerFunction())
+    }
+
+    fun PATCH(pattern: String): RequestPredicate = RequestPredicates.PATCH(pattern)
+
+    fun <T : CoroutineServerResponse> HEAD(pattern: String, f: CoroutineHandlerFunction<T>) {
+        routes += route(RequestPredicates.HEAD(pattern), f.asHandlerFunction())
+    }
+
+    fun HEAD(pattern: String): RequestPredicate = RequestPredicates.HEAD(pattern)
+
+    fun <T : CoroutineServerResponse> OPTIONS(pattern: String, f: CoroutineHandlerFunction<T>) {
+        routes += route(RequestPredicates.OPTIONS(pattern), f.asHandlerFunction())
+    }
+
+    fun OPTIONS(pattern: String): RequestPredicate = RequestPredicates.OPTIONS(pattern)
 
     fun path(pattern: String): RequestPredicate = RequestPredicates.path(pattern)
 
@@ -67,24 +111,20 @@ class CoroutineRouterFunctionDsl {
         routes += route(RequestPredicates.pathExtension(extension), f.asHandlerFunction())
     }
 
-    fun <T: CoroutineServerResponse> POST(pattern: String, f: CoroutineHandlerFunction<T>) {
-        routes += route(RequestPredicates.POST(pattern), f.asHandlerFunction())
-    }
-
     fun router(): RouterFunction<ServerResponse> {
         return routes.reduce(RouterFunction<ServerResponse>::and)
     }
 
-    operator fun <T: CoroutineServerResponse> RequestPredicate.invoke(f: CoroutineHandlerFunction<T>) {
+    operator fun <T : CoroutineServerResponse> RequestPredicate.invoke(f: CoroutineHandlerFunction<T>) {
         routes += route(this, f.asHandlerFunction())
     }
 
-    private fun <T: CoroutineServerResponse> CoroutineHandlerFunction<T>.asHandlerFunction() = HandlerFunction {
+    private fun <T : CoroutineServerResponse> CoroutineHandlerFunction<T>.asHandlerFunction() = HandlerFunction {
         mono(Unconfined) {
             this@asHandlerFunction.invoke(org.springframework.web.coroutine.function.server.CoroutineServerRequest(it))?.extractServerResponse()
         }
     }
 }
 
-operator fun <T: ServerResponse> RouterFunction<T>.plus(other: RouterFunction<T>) =
-        this.and(other)
+operator fun <T : ServerResponse> RouterFunction<T>.plus(other: RouterFunction<T>) =
+    this.and(other)

--- a/spring-webflux-kotlin-coroutine/src/test/kotlin/org/springframework/kotlin/experimental/coroutine/web/FunctionalStyleRoutesConfiguration.kt
+++ b/spring-webflux-kotlin-coroutine/src/test/kotlin/org/springframework/kotlin/experimental/coroutine/web/FunctionalStyleRoutesConfiguration.kt
@@ -32,17 +32,32 @@ open class FunctionalStyleRoutesConfiguration {
 
     @Bean
     open fun apiRouter(handler: FunctionalHandler) = router {
-        (accept(MediaType.APPLICATION_JSON) and "/test").nest {
-            GET("/simple/{param}") { handler.simple(it) }
+        "/test-functional".nest {
+            (accept(MediaType.APPLICATION_JSON) and  "/").nest {
+                GET("/simple/{param}") { handler.simpleGet(it) }
+            }
+
+            ("/" and contentType(MediaType.APPLICATION_JSON)).nest {
+                POST("/simple") { handler.simplePost(it) }
+                PUT("/simple/{id}") { handler.simplePut(it) }
+            }
+
+            DELETE("/simple/{id}") { handler.simpleDelete(it) }
         }
     }
 }
 
 @Component
 open class FunctionalHandler {
-    suspend fun simple(req: CoroutineServerRequest) =
-        CoroutineServerResponse
-                .ok()
-                .contentType(MediaType.TEXT_PLAIN)
-                .body(req.pathVariable("param"))
+    suspend fun simpleGet(req: CoroutineServerRequest) =
+        CoroutineServerResponse.ok().contentType(MediaType.TEXT_PLAIN).body(req.pathVariable("param"))
+
+    suspend fun simplePost(req: CoroutineServerRequest) =
+        CoroutineServerResponse.created(req.uri()).body(mapOf(req.body<Map<String, String>>()!!["key"] to "pong"))
+
+    suspend fun simplePut(req: CoroutineServerRequest) =
+        CoroutineServerResponse.noContent().build()
+
+    suspend fun simpleDelete(req: CoroutineServerRequest) =
+        CoroutineServerResponse.noContent().build()
 }


### PR DESCRIPTION
Added missing **PUT**, **DELETE**, **PATCH**, **OPTIONS**, **HEAD** methods to router function, as well as **and**, **or** infixes and **not** operator.

Moved `CoroutineServerResponse` builder `build()` method from **body builder** to **header builder**, as building response shouldn't require to have a body, e.g. `CoroutineServerResponse.noContent().build()` 