### PR TITLE
MongoRepository.deleteAll fixed passing of iterable

### DIFF
--- a/spring-boot-autoconfigure-kotlin-coroutine/src/test/groovy/org/springframework/data/mongodb/repository/CoroutineMongoRepositoryIntSpec.groovy
+++ b/spring-boot-autoconfigure-kotlin-coroutine/src/test/groovy/org/springframework/data/mongodb/repository/CoroutineMongoRepositoryIntSpec.groovy
@@ -176,4 +176,27 @@ class CoroutineMongoRepositoryIntSpec extends Specification {
         ENTITY_ID        | true
         "abcd"           | false
     }
+
+    def "should delete entities by collection"() {
+        given:
+        def entity2 = new TestEntity()
+        entity2.id = "id-2"
+        def entity3 = new TestEntity()
+        entity3.id = "id-3"
+        runBlocking { cont ->
+            testRepository.saveAll([entity2, entity3], cont)
+        }
+
+        when:
+        runBlocking { cont ->
+            testRepository.deleteAll([entity3], cont)
+        }
+
+        then:
+        def result = runBlocking { cont ->
+            testRepository.findAll(cont)
+        }
+
+        result.size() ==  2
+    }
 }

--- a/spring-data-mongodb-kotlin-coroutine/src/main/kotlin/org/springframework/data/mongodb/repository/support/SimpleCoroutineMongoRepository.kt
+++ b/spring-data-mongodb-kotlin-coroutine/src/main/kotlin/org/springframework/data/mongodb/repository/support/SimpleCoroutineMongoRepository.kt
@@ -60,7 +60,7 @@ open class SimpleCoroutineMongoRepository<T, ID: Serializable>(
     }
 
     override suspend fun deleteAll(entities: Iterable<T>) {
-        reactiveRepo.deleteAll().awaitFirstOrDefault(null)
+        reactiveRepo.deleteAll(entities).awaitFirstOrDefault(null)
     }
 
     override suspend fun <S : T> insert(entity: S): S? =


### PR DESCRIPTION
Fixed missing passing of iterable to reactive repo on `deleteAll()` method call